### PR TITLE
Update tsconfig to exclude tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,31 +14,28 @@
     "noImplicitThis": true,
     "outDir": "dist",
     "rootDir": ".",
-    "types": ["jest", "node"],
+    "types": ["node"],
     "allowJs": true,
     "checkJs": false
   },
   "include": [
-    // Include root files
     "./",
-    // Include all ts files
     "./**/*.ts",
-    // Include all js files
     "./**/*.js",
-    // Force the JSON files in the src folder to be included
     "src/**/*.json"
   ],
-
   "exclude": [
     "node_modules/",
     "build/",
     "dist/",
     ".cache/",
     ".tmp/",
-
-    // Do not include admin files in the server compilation
+    "tests/",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.js",
+    "**/*.test.js",
     "src/admin/",
-    // Do not include plugins in the server compilation
     "src/plugins/**"
   ]
 }


### PR DESCRIPTION
Exclude test files from TypeScript compilation to fix production build errors.

This change removes `jest` from the `types` array and adds comprehensive exclusions for test files (`tests/`, `*.spec.ts`, `*.test.ts`, `*.spec.js`, `*.test.js`) in `tsconfig.json`. This prevents Jest-related types from interfering with the production build, which was causing deployment failures.