### PR TITLE
Fix duplicate friends content type

### DIFF
--- a/src/api/friends/content-types/friends/schema.json
+++ b/src/api/friends/content-types/friends/schema.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "friends",
   "info": {
-    "singularName": "friends",
+    "singularName": "friend",
     "pluralName": "friends",
     "displayName": "Friends",
     "description": "Friendships between users"


### PR DESCRIPTION
Fix Strapi startup error by correcting the singular name for the 'friends' content type.

The error "The plural name 'friends' should be unique" occurred because the `singularName` and `pluralName` for the `friends` content type were both set to "friends". Strapi requires the `singularName` to be the singular form, which was causing a conflict in its content type system. Changing `singularName` to "friend" resolves this.