### PR TITLE
Fix strapi policy next function error

### DIFF
--- a/src/policies/isAuthenticated.ts
+++ b/src/policies/isAuthenticated.ts
@@ -1,7 +1,7 @@
-export default async (ctx: any, next: any) => {
+export default (ctx: any, next: any) => {
   if (!ctx.state.user) {
     return ctx.unauthorized('Authentication required');
   }
   
-  await next();
+  return next();
 };


### PR DESCRIPTION
Fix 'next is not a function' error in Strapi authentication policy by correcting its function signature.

The error occurred because the `isAuthenticated` policy was defined as an `async` arrow function and used `await next()`. Strapi policies expect a synchronous function that returns `next()`. This change aligns the policy with the expected Strapi middleware pattern, ensuring proper middleware chain execution.